### PR TITLE
attempt to detect user locale based on accept-language header

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -18,8 +18,8 @@ export default getRequestConfig(async () => {
   const locale = await getUserLocale();
 
   let messages: MessageCatalog;
-  if (LOCALES.includes(locale as Locale)) {
-    messages = await loadMessageCatalog(locale as Locale);
+  if (LOCALES.includes(locale)) {
+    messages = await loadMessageCatalog(locale);
   }
   if (locale !== DEFAULT_LOCALE) {
     const fallback = await loadMessageCatalog(DEFAULT_LOCALE);

--- a/src/server/locale.ts
+++ b/src/server/locale.ts
@@ -26,12 +26,12 @@ async function getBrowserLocale(): Promise<Locale | undefined> {
   return locale;
 }
 
-export async function getUserLocale() {
+export async function getUserLocale(): Promise<Locale> {
   return (
     (await getCookieLocale()) ?? (await getBrowserLocale()) ?? DEFAULT_LOCALE
   );
 }
 
-export async function setUserLocale(locale: Locale) {
+export async function setUserLocale(locale: Locale): Promise<void> {
   (await cookies()).set(COOKIE_NAME, locale);
 }

--- a/src/server/locale.ts
+++ b/src/server/locale.ts
@@ -1,12 +1,35 @@
 "use server";
 
-import { cookies } from "next/headers";
-import { type Locale, DEFAULT_LOCALE } from "~/i18n/config";
+import { cookies, headers } from "next/headers";
+import { type Locale, DEFAULT_LOCALE, LOCALES } from "~/i18n/config";
 
 const COOKIE_NAME = "NEXT_LOCALE";
 
+function isValidLocale(locale: string): locale is Locale {
+  return (LOCALES as string[]).includes(locale);
+}
+
+async function getCookieLocale(): Promise<Locale | undefined> {
+  const cookieLocale = (await cookies()).get(COOKIE_NAME)?.value;
+  if (!cookieLocale) return undefined;
+  if (!isValidLocale(cookieLocale)) return undefined;
+  return cookieLocale;
+}
+
+async function getBrowserLocale(): Promise<Locale | undefined> {
+  const acceptLanguage = (await headers()).get("accept-language");
+  if (!acceptLanguage) return undefined;
+
+  const locale = acceptLanguage.split(",")[0]?.split("-")[0];
+  if (!locale) return undefined;
+  if (!isValidLocale(locale)) return undefined;
+  return locale;
+}
+
 export async function getUserLocale() {
-  return (await cookies()).get(COOKIE_NAME)?.value ?? DEFAULT_LOCALE;
+  return (
+    (await getCookieLocale()) ?? (await getBrowserLocale()) ?? DEFAULT_LOCALE
+  );
 }
 
 export async function setUserLocale(locale: Locale) {


### PR DESCRIPTION
makes it so the user locale is automatically selected based on accept-language header when no other preference (e.g. cookie) is set