### PR TITLE
 detect user locale based on accept-language header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@trpc/server": "^11.4.4",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
+        "accept-language-parser": "^1.5.0",
         "deepmerge": "^4.3.1",
         "flag-icons": "^7.5.0",
         "next": "^15.5.2",
@@ -32,6 +33,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
+        "@types/accept-language-parser": "^1.5.8",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.3.1",
         "@types/react": "^19.1.12",
@@ -2751,6 +2753,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/accept-language-parser": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@types/accept-language-parser/-/accept-language-parser-1.5.8.tgz",
+      "integrity": "sha512-6+dKdh9q/I8xDBnKQKddCBKaWBWLmJ97HTiSbAXVpL7LEgDfOkKF98UVCaZ5KJrtdN5Wa5ndXUiqD3XR9XGqWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4429,6 +4438,12 @@
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.22.1.tgz",
       "integrity": "sha512-VXY4gjHaTENHW+wjnKKENZ2jcaW0vnG2a5lYEMuZR4dpNCKH217yFr/bCNrI44y2s1W3LWhWmpEjfZluP6udYg==",
+      "license": "MIT"
+    },
+    "node_modules/accept-language-parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.5.0.tgz",
+      "integrity": "sha512-QhyTbMLYo0BBGg1aWbeMG4ekWtds/31BrEU+DONOg/7ax23vxpL03Pb7/zBmha2v7vdD3AyzZVWBVGEZxKOXWw==",
       "license": "MIT"
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@trpc/server": "^11.4.4",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
+    "accept-language-parser": "^1.5.0",
     "deepmerge": "^4.3.1",
     "flag-icons": "^7.5.0",
     "next": "^15.5.2",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
+    "@types/accept-language-parser": "^1.5.8",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.3.1",
     "@types/react": "^19.1.12",

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -18,8 +18,8 @@ export default getRequestConfig(async () => {
   const locale = await getUserLocale();
 
   let messages: MessageCatalog;
-  if (LOCALES.includes(locale as Locale)) {
-    messages = await loadMessageCatalog(locale as Locale);
+  if (LOCALES.includes(locale)) {
+    messages = await loadMessageCatalog(locale);
   }
   if (locale !== DEFAULT_LOCALE) {
     const fallback = await loadMessageCatalog(DEFAULT_LOCALE);

--- a/src/server/locale.ts
+++ b/src/server/locale.ts
@@ -26,12 +26,12 @@ async function getBrowserLocale(): Promise<Locale | undefined> {
   return locale;
 }
 
-export async function getUserLocale() {
+export async function getUserLocale(): Promise<Locale> {
   return (
     (await getCookieLocale()) ?? (await getBrowserLocale()) ?? DEFAULT_LOCALE
   );
 }
 
-export async function setUserLocale(locale: Locale) {
+export async function setUserLocale(locale: Locale): Promise<void> {
   (await cookies()).set(COOKIE_NAME, locale);
 }

--- a/src/server/locale.ts
+++ b/src/server/locale.ts
@@ -1,12 +1,35 @@
 "use server";
 
-import { cookies } from "next/headers";
-import { type Locale, DEFAULT_LOCALE } from "~/i18n/config";
+import { cookies, headers } from "next/headers";
+import { type Locale, DEFAULT_LOCALE, LOCALES } from "~/i18n/config";
 
 const COOKIE_NAME = "NEXT_LOCALE";
 
+function isValidLocale(locale: string): locale is Locale {
+  return (LOCALES as string[]).includes(locale);
+}
+
+async function getCookieLocale(): Promise<Locale | undefined> {
+  const cookieLocale = (await cookies()).get(COOKIE_NAME)?.value;
+  if (!cookieLocale) return undefined;
+  if (!isValidLocale(cookieLocale)) return undefined;
+  return cookieLocale;
+}
+
+async function getBrowserLocale(): Promise<Locale | undefined> {
+  const acceptLanguage = (await headers()).get("accept-language");
+  if (!acceptLanguage) return undefined;
+
+  const locale = acceptLanguage.split(",")[0]?.split("-")[0];
+  if (!locale) return undefined;
+  if (!isValidLocale(locale)) return undefined;
+  return locale;
+}
+
 export async function getUserLocale() {
-  return (await cookies()).get(COOKIE_NAME)?.value ?? DEFAULT_LOCALE;
+  return (
+    (await getCookieLocale()) ?? (await getBrowserLocale()) ?? DEFAULT_LOCALE
+  );
 }
 
 export async function setUserLocale(locale: Locale) {


### PR DESCRIPTION
makes it so the user locale is automatically selected based on accept-language header when no other preference (e.g. cookie) is set.
automatically selects the user's most preferred locale the application supports
