### PR TITLE
fix sign-in simulation page not working correctly without branding

### DIFF
--- a/src/components/ms/signin.tsx
+++ b/src/components/ms/signin.tsx
@@ -449,7 +449,11 @@ export default function MSConvergedSignInPage() {
   const onUsernameSubmit = async () => {
     if (!username) return;
 
-    await branding.mutateAsync({ username });
+    try {
+      await branding.mutateAsync({ username });
+    } catch (error) {
+      console.error("getBranding failed:", error);
+    }
 
     setPage("password");
   };

--- a/src/server/api/routers/branding.ts
+++ b/src/server/api/routers/branding.ts
@@ -25,7 +25,7 @@ const credentialTypeSchema = z.object({
           Favicon: z.string().optional(),
         }),
       )
-      .optional(),
+      .nullable(), // UserTenantBranding may be null if nothing is configured
   }),
 });
 
@@ -50,7 +50,7 @@ export const brandingRouter = createTRPCRouter({
 
       const credentialType = credentialTypeSchema.parse(await response.json());
       const brandingData =
-        credentialType.EstsProperties.UserTenantBranding?.at(0);
+        credentialType.EstsProperties?.UserTenantBranding?.at(0);
 
       return {
         userDisplayName: credentialType.Display,

--- a/src/server/api/routers/branding.ts
+++ b/src/server/api/routers/branding.ts
@@ -50,7 +50,7 @@ export const brandingRouter = createTRPCRouter({
 
       const credentialType = credentialTypeSchema.parse(await response.json());
       const brandingData =
-        credentialType.EstsProperties?.UserTenantBranding?.at(0);
+        credentialType.EstsProperties.UserTenantBranding?.at(0);
 
       return {
         userDisplayName: credentialType.Display,


### PR DESCRIPTION
fixes an issue where the sign-in simulation page would fail to continue to the password entry form when the target tenant does not have any branding configured.
the pr introduces two fixes:
- one specialized one, where the validation schema for the request is corrected
- one general one, that fails to a useable state whenever the branding request fails